### PR TITLE
Add functionality for non-uniform timestep

### DIFF
--- a/examples/meandergraph_Mamore_banks_simple_example.ipynb
+++ b/examples/meandergraph_Mamore_banks_simple_example.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,17 +120,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# comment this cell out if you selected points in the previous cell using ginput\n",
     "points = [(286850.39156848995, -1660631.8404876508),\n",
     " (284610.488612104, -1650178.960024516)]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,18 +246,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "ts = len(X1)\n",
-    "graph1 = mg.create_graph_from_channel_lines(X1[:ts], Y1[:ts], P1[:ts-1], Q1[:ts-1], n_points=20, max_dist=1000, remove_cutoff_edges=True)\n",
-    "graph2 = mg.create_graph_from_channel_lines(X2[:ts], Y2[:ts], P2[:ts-1], Q2[:ts-1], n_points=20, max_dist=1000, remove_cutoff_edges=True)"
+    "timesteps = [1.0] * len(X1) # create a list of timesteps; elements have units of years. In this case the timestep is 1 year\n",
+    "graph1 = mg.create_graph_from_channel_lines(X1[:ts], Y1[:ts], P1[:ts-1], Q1[:ts-1], n_points=20, max_dist=1000, smoothing_factor = 51, remove_cutoff_edges=True, timesteps = timesteps)\n",
+    "graph2 = mg.create_graph_from_channel_lines(X2[:ts], Y2[:ts], P2[:ts-1], Q2[:ts-1], n_points=20, max_dist=1000, smoothing_factor= 51, remove_cutoff_edges=True, timesteps = timesteps)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,12 +270,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### View node attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph1.nodes[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Plot one of the graphs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 382,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,31 +347,44 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Create and plot 'bar graphs', colored by migration rate"
+    "### Create 'bar graphs'"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "# create bars and bar graphs\n",
     "min_area = 1000\n",
     "wbars, poly_graph_1, poly_graph_2 = mg.create_polygon_graphs_and_bar_graphs(graph1, graph2, all_bars_graph, \n",
-    "                                                    scrolls, scroll_ages, cutoffs, X1, Y1, X2, Y2, min_area)"
+    "                                                    scrolls, scroll_ages, X1, Y1, X2, Y2, min_area)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot 'bar' graphs, colored by an attribute"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Color by migration rate"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# plot them, using migration rate\n",
     "fig = plt.figure(figsize = (12, 12)) \n",
     "ax = fig.add_subplot(111)\n",
-    "mg.plot_bar_graphs(graph1, graph2, wbars, ts, cutoffs, 356*24*60*60, X1, Y1, X2, Y2, 300, 1, -500, 500, 'migration', ax)\n",
+    "mg.plot_bar_graphs(graph1, graph2, wbars, cutoffs, X1, Y1, X2, Y2, 300, -500, 500, 'migration', ax)\n",
     "ax.set_adjustable(\"box\")\n",
     "ax.axis('equal')\n",
     "fig.tight_layout()"
@@ -363,97 +394,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Plot bank polygon graphs, colored by age"
+    "#### Color by age"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import matplotlib as mpl\n",
-    "fig = plt.figure()\n",
+    "# plot them, using migration rate\n",
+    "fig = plt.figure(figsize = (12, 12)) \n",
     "ax = fig.add_subplot(111)\n",
-    "norm = mpl.colors.Normalize(vmin=0, vmax=len(X1))\n",
-    "m = mpl.cm.ScalarMappable(norm=norm, cmap='viridis')\n",
-    "for node in poly_graph_1.nodes:\n",
-    "        poly = poly_graph_1.nodes[node]['poly']\n",
-    "        if type(poly) == Polygon:\n",
-    "            ax.fill(poly.exterior.xy[0], poly.exterior.xy[1], \n",
-    "                facecolor = m.to_rgba(poly_graph_1.nodes[node]['age']), \n",
-    "                edgecolor='k', linewidth=0.25, alpha=0.4)\n",
-    "plt.axis('equal');"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib as mpl\n",
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(111)\n",
-    "norm = mpl.colors.Normalize(vmin=0, vmax=len(X1))\n",
-    "m = mpl.cm.ScalarMappable(norm=norm, cmap='viridis')\n",
-    "for node in poly_graph_2.nodes:\n",
-    "        poly = poly_graph_2.nodes[node]['poly']\n",
-    "        if type(poly) == Polygon:\n",
-    "            ax.fill(poly.exterior.xy[0], poly.exterior.xy[1], \n",
-    "                facecolor = m.to_rgba(poly_graph_2.nodes[node]['age']), \n",
-    "                edgecolor='k', linewidth=0.25, alpha=0.4)\n",
-    "plt.axis('equal');"
+    "mg.plot_bar_graphs(graph1, graph2, wbars, cutoffs, X1, Y1, X2, Y2, 300, 0, len(X1), 'age', ax)\n",
+    "ax.set_adjustable(\"box\")\n",
+    "ax.axis('equal')\n",
+    "fig.tight_layout()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Plot bank polygon graphs, colored by migartion rate"
+    "### View polygon graph node attributes"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(111)\n",
-    "norm = mpl.colors.Normalize(vmin=-100, vmax=100)\n",
-    "m = mpl.cm.ScalarMappable(norm=norm, cmap='coolwarm_r')\n",
-    "for node in tqdm(poly_graph_2.nodes):\n",
-    "        poly = poly_graph_2.nodes[node]['poly']\n",
-    "        if type(poly) == Polygon:\n",
-    "            ax.fill(poly.exterior.xy[0], poly.exterior.xy[1], \n",
-    "                facecolor = m.to_rgba(poly_graph_2.nodes[node]['migr_rate']*poly_graph_2.nodes[node]['direction']), \n",
-    "                edgecolor='k', linewidth=0.25, alpha=0.4)\n",
-    "plt.axis('equal');"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig = plt.figure()\n",
-    "ax = fig.add_subplot(111)\n",
-    "norm = mpl.colors.Normalize(vmin=-100, vmax=100)\n",
-    "m = mpl.cm.ScalarMappable(norm=norm, cmap='coolwarm')\n",
-    "for node in tqdm(poly_graph_1.nodes):\n",
-    "        poly = poly_graph_1.nodes[node]['poly']\n",
-    "        if type(poly) == Polygon:\n",
-    "            ax.fill(poly.exterior.xy[0], poly.exterior.xy[1], \n",
-    "                facecolor = m.to_rgba(poly_graph_1.nodes[node]['migr_rate']*poly_graph_1.nodes[node]['direction']), \n",
-    "                edgecolor='k', linewidth=0.25, alpha=0.4)\n",
-    "plt.axis('equal');"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,26 +457,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 31,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# add curvature attribute to bankline graphs (needed for curvature maps)\n",
-    "mg.add_curvature_to_line_graph(graph1, smoothing_factor = 51)\n",
-    "mg.add_curvature_to_line_graph(graph2, smoothing_factor = 51)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 52,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "graph1.nodes[1000]['curv']"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -517,14 +465,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure()\n",
     "ax = fig.add_subplot(111)\n",
     "ax.fill(wbars[2].polygon.exterior.xy[0], wbars[2].polygon.exterior.xy[1])\n",
-    "mg.plot_migration_rate_map(wbars[2], graph1, graph2, vmin=-300, vmax=300, dt=365*24*60*60, saved_ts=1, ax=ax)\n",
+    "mg.plot_migration_rate_map(wbars[2], graph1, graph2, vmin=-300, vmax=300, ax=ax)\n",
     "plt.axis('equal');"
    ]
   },
@@ -537,13 +485,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "fig = plt.figure()\n",
     "ax = fig.add_subplot(111)\n",
-    "mg.plot_age_map(wbars[1], vmin=0, vmax=ts, ax=ax)\n",
+    "mg.plot_age_map(wbars[1], vmin=0, vmax=len(X1), ax=ax)\n",
     "plt.axis('equal');"
    ]
   },
@@ -556,11 +504,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# plot bar polygons and their numbers\n",
     "fig = plt.figure(figsize = (15, 9))\n",
     "ax = fig.add_subplot(111)\n",
     "for wbar in wbars:\n",
@@ -586,7 +533,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +565,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -642,7 +589,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/examples/meandergraph_example.ipynb
+++ b/examples/meandergraph_example.ipynb
@@ -238,7 +238,8 @@
    "source": [
     "plt.figure()\n",
     "plt.plot(X1[100], Y1[100])\n",
-    "plt.plot(X2[100], Y2[100])"
+    "plt.plot(X2[100], Y2[100])\n",
+    "plt.axis('equal')"
    ]
   },
   {
@@ -254,11 +255,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# reload(mg)\n",
     "ts = len(X)\n",
-    "graph = mg.create_graph_from_channel_lines(X[:ts], Y[:ts], P[:ts-1], Q[:ts-1], n_points=20, max_dist=100, remove_cutoff_edges=True)\n",
-    "graph1 = mg.create_graph_from_channel_lines(X1[:ts], Y1[:ts], P1[:ts-1], Q1[:ts-1], n_points=20, max_dist=100, remove_cutoff_edges=True)\n",
-    "graph2 = mg.create_graph_from_channel_lines(X2[:ts], Y2[:ts], P2[:ts-1], Q2[:ts-1], n_points=20, max_dist=100, remove_cutoff_edges=True)"
+    "timesteps = [dt * saved_ts/(365*24*60*60)] * len(X) # create a list of timesteps; elements have units of years\n",
+    "graph = mg.create_graph_from_channel_lines(X[:ts], Y[:ts], P[:ts-1], Q[:ts-1], n_points=20, max_dist=100, smoothing_factor= 51, remove_cutoff_edges=True, timesteps = timesteps)\n",
+    "graph1 = mg.create_graph_from_channel_lines(X1[:ts], Y1[:ts], P1[:ts-1], Q1[:ts-1], n_points=20, max_dist=100, smoothing_factor= 51, remove_cutoff_edges=True, timesteps = timesteps)\n",
+    "graph2 = mg.create_graph_from_channel_lines(X2[:ts], Y2[:ts], P2[:ts-1], Q2[:ts-1], n_points=20, max_dist=100, smoothing_factor= 51, remove_cutoff_edges=True, timesteps = timesteps)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Remove high density nodes"
    ]
   },
   {
@@ -270,6 +278,22 @@
     "graph = mg.remove_high_density_nodes(graph, min_dist = 10, max_dist = 30)\n",
     "graph1 = mg.remove_high_density_nodes(graph1, min_dist = 10, max_dist = 30)\n",
     "graph2 = mg.remove_high_density_nodes(graph2, min_dist = 10, max_dist = 30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### View node attributes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph.nodes[0]"
    ]
   },
   {
@@ -327,7 +351,7 @@
     "# create bars and bar graphs\n",
     "min_area = 5000\n",
     "wbars, poly_graph_1, poly_graph_2 = mg.create_polygon_graphs_and_bar_graphs(graph1, graph2, all_bars_graph, \n",
-    "                                                                scrolls, scroll_ages, cutoffs, X1, Y1, X2, Y2, min_area)"
+    "                                                                scrolls, scroll_ages, X1, Y1, X2, Y2, min_area)"
    ]
   },
   {
@@ -353,8 +377,8 @@
     "# plot them, using migration rate\n",
     "fig = plt.figure(figsize = (12, 12)) \n",
     "ax = fig.add_subplot(111)\n",
-    "mg.plot_bar_graphs(graph1, graph2, wbars, ts, cutoffs, dt, X1, Y1, X2, Y2, W, \n",
-    "                   saved_ts, 0, 40, 'migration', ax)\n",
+    "mg.plot_bar_graphs(graph1, graph2, wbars, cutoffs, X1, Y1, X2, Y2, \n",
+    "                   W, -40, 40, 'migration', ax)\n",
     "ax.set_adjustable(\"box\")\n",
     "ax.axis('equal')\n",
     "fig.tight_layout()"
@@ -373,22 +397,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# add curvature attribute to bankline graphs (needed for curvature maps)\n",
-    "mg.add_curvature_to_line_graph(graph1, smoothing_factor = 21)\n",
-    "mg.add_curvature_to_line_graph(graph2, smoothing_factor = 21)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# plot curvature map\n",
     "fig = plt.figure()\n",
     "ax = fig.add_subplot(111)\n",
-    "mg.plot_bar_graphs(graph1, graph2, wbars, ts, cutoffs, dt, X1, Y1, X2, Y2, W, \n",
-    "                   saved_ts, 0, 0.8, 'curvature', ax)\n",
+    "mg.plot_bar_graphs(graph1, graph2, wbars, cutoffs, X1, Y1, X2, Y2, \n",
+    "                   W, 0, 0.8, 'curvature', ax)\n",
     "plt.axis('equal');"
    ]
   },
@@ -408,8 +421,8 @@
     "# plot age map\n",
     "fig = plt.figure()\n",
     "ax = fig.add_subplot(111)\n",
-    "mg.plot_bar_graphs(graph1, graph2, wbars, ts, cutoffs, dt, X1, Y1, X2, Y2, W, \n",
-    "                   saved_ts, 0, ts, 'age', ax)\n",
+    "mg.plot_bar_graphs(graph1, graph2, wbars, cutoffs, X1, Y1, X2, Y2, \n",
+    "                   W, 0, ts, 'age', ax)\n",
     "plt.axis('equal');"
    ]
   },
@@ -426,15 +439,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# plot bar polygons and their numbers\n",
     "fig = plt.figure(figsize = (15, 9))\n",
     "ax = fig.add_subplot(111)\n",
     "for wbar in wbars:\n",
-    "    ax.add_patch(PolygonPatch(wbar.polygon))\n",
-    "count = 0\n",
-    "for wbar in wbars:\n",
-    "    ax.text(wbar.polygon.centroid.x, wbar.polygon.centroid.y, str(count), fontsize = 16)\n",
-    "    count += 1\n",
+    "   if wbar.polygon.geom_type == 'Polygon':\n",
+    "    wbar.add_bank_type() # add bank type\n",
+    "    if wbar.bank_type == 'right':\n",
+    "        plt.fill(wbar.polygon.exterior.xy[0], wbar.polygon.exterior.xy[1], color='r')\n",
+    "    if wbar.bank_type == 'left':\n",
+    "        plt.fill(wbar.polygon.exterior.xy[0], wbar.polygon.exterior.xy[1], color='b')\n",
+    "    count = 0\n",
+    "    for wbar in wbars:\n",
+    "        ax.text(wbar.polygon.centroid.x, wbar.polygon.centroid.y, str(count), fontsize = 16)\n",
+    "        count += 1\n",
     "plt.axis('equal');"
    ]
   },
@@ -453,7 +470,7 @@
    "source": [
     "fig = plt.figure()\n",
     "ax = fig.add_subplot(111)\n",
-    "mg.plot_migration_rate_map(wbars[2], graph1, graph2, 0, 40, dt, saved_ts, ax)\n",
+    "mg.plot_migration_rate_map(wbars[2], graph1, graph2, 0, 40, ax)\n",
     "plt.axis('equal');"
    ]
   },
@@ -573,7 +590,7 @@
     "                        ax.add_patch(PolygonPatch(graph_poly.nodes[node]['poly'], facecolor = cmap(0), edgecolor='k', \n",
     "                                                  linewidth = 0.3, alpha = 0.5, zorder = count))\n",
     "        count += 1\n",
-    "plt.axis('equal');                    "
+    "plt.axis('equal');"
    ]
   },
   {
@@ -594,11 +611,13 @@
    },
    "outputs": [],
    "source": [
-    "# # ts = 50\n",
-    "# for ts in range(5, 140):\n",
-    "#     graph = mg.create_graph_from_channel_lines(X[:ts], Y[:ts], P[:ts-1], Q[:ts-1], n_points=20, max_dist=100, remove_cutoff_edges=True)\n",
-    "#     graph1 = mg.create_graph_from_channel_lines(X1[:ts], Y1[:ts], P1[:ts-1], Q1[:ts-1], n_points=20, max_dist=100, remove_cutoff_edges=True)\n",
-    "#     graph2 = mg.create_graph_from_channel_lines(X2[:ts], Y2[:ts], P2[:ts-1], Q2[:ts-1], n_points=20, max_dist=100, remove_cutoff_edges=True)\n",
+    "# timesteps = [dt * saved_ts/(365*24*60*60)] * len(X)\n",
+    "# min_area = 500\n",
+    "# for ts in range(100, 101):\n",
+    "\n",
+    "#     graph = mg.create_graph_from_channel_lines(X[:ts], Y[:ts], P[:ts-1], Q[:ts-1], n_points=20, max_dist=100, smoothing_factor=51, remove_cutoff_edges=True, timesteps = timesteps)\n",
+    "#     graph1 = mg.create_graph_from_channel_lines(X1[:ts], Y1[:ts], P1[:ts-1], Q1[:ts-1], n_points=20, max_dist=100, smoothing_factor=51, remove_cutoff_edges=True, timesteps = timesteps)\n",
+    "#     graph2 = mg.create_graph_from_channel_lines(X2[:ts], Y2[:ts], P2[:ts-1], Q2[:ts-1], n_points=20, max_dist=100, smoothing_factor=51, remove_cutoff_edges=True, timesteps = timesteps)\n",
     "    \n",
     "#     graph = mg.remove_high_density_nodes(graph, min_dist = 10, max_dist = 30)\n",
     "#     graph1 = mg.remove_high_density_nodes(graph1, min_dist = 10, max_dist = 30)\n",
@@ -608,23 +627,22 @@
     "#     fig = plt.figure()\n",
     "#     ax = fig.add_subplot(111)\n",
     "#     scrolls, scroll_ages, all_bars_graph, cutoffs = mg.create_scrolls_and_find_connected_scrolls(graph1, graph2, cutoff_area)\n",
-    "#     plt.axis('equal');\n",
-    "    \n",
+    "\n",
     "#     # create bars and bar graphs:\n",
     "#     wbars, poly_graph_1, poly_graph_2 = mg.create_polygon_graphs_and_bar_graphs(graph1, graph2, all_bars_graph, \n",
-    "#                                                                     scrolls, scroll_ages, cutoffs, X1, Y1, ax)\n",
-    "#     # add polygon widths and lengths to bar graphs (needed for migration rate maps):\n",
-    "#     mg.add_polygon_width_and_length(wbars, graph1, graph2)\n",
+    "#                                                                     scrolls, scroll_ages, X1, Y1, X2, Y2, min_area)\n",
+    "\n",
     "\n",
     "#     fig = plt.figure(figsize = (12, 12)) \n",
     "#     ax = fig.add_subplot(111)\n",
-    "#     mg.plot_bar_graphs(graph1, graph2, wbars, ts, cutoffs, dt, X, Y, W, saved_ts, 0, 40, 'migration', ax)\n",
+    "#     mg.plot_bar_graphs(graph1, graph2, wbars, cutoffs, X, Y, W, -40, 40, 'migration', ax)\n",
     "#     ax.set_adjustable(\"box\")\n",
     "#     ax.axis('equal')\n",
     "#     fig.tight_layout()\n",
-    "#     ax.set_xlim(xlim)\n",
-    "#     ax.set_ylim(ylim)\n",
-    "#     fname = 'example_2_'+'%03d.png'%(ts-5)\n",
+    "#     #ax.set_xlim(xlim)\n",
+    "#     #ax.set_ylim(ylim)\n",
+    "#     #fname = 'example_2_'+'%03d.png'%(ts-5)\n",
+    "#     fname = '/Users/cole/Downloads/example_2_'+'%03d.png'%(ts-5)\n",
     "#     fig.savefig(fname, bbox_inches='tight')\n",
     "#     plt.close('all')"
    ]
@@ -645,10 +663,10 @@
     "# code for debugging bar polygons\n",
     "from shapely.geometry import Point\n",
     "\n",
-    "def debug_bar_polygons(wbar, line_graph, dt, saved_ts):\n",
+    "def debug_bar_polygons(wbar, line_graph):\n",
     "    fig = plt.figure()\n",
     "    ax = fig.add_subplot(111)\n",
-    "    mg.plot_migration_rate_map(wbar, line_graph, vmin=0, vmax=40, dt=dt, saved_ts=saved_ts, ax=ax)\n",
+    "    mg.plot_migration_rate_map(wbar, graph1, graph2, 0, 40, ax)\n",
     "    plt.axis('equal');\n",
     "    nodes = []\n",
     "    for node in line_graph.nodes:\n",
@@ -660,10 +678,10 @@
     "        plt.text(line_graph.nodes[node]['x'], line_graph.nodes[node]['y'], str(node))\n",
     "    return fig\n",
     "\n",
-    "def debug_bar_polygons_2(wbar, line_graph, dt, saved_ts):\n",
+    "def debug_bar_polygons_2(wbar, line_graph):\n",
     "    fig = plt.figure()\n",
     "    ax = fig.add_subplot(111)\n",
-    "    mg.plot_migration_rate_map(wbar, line_graph, vmin=0, vmax=40, dt=dt, saved_ts=saved_ts, ax=ax)\n",
+    "    mg.plot_migration_rate_map(wbars[2], graph1, graph2, 0, 40, ax)\n",
     "    plt.axis('equal');\n",
     "    for node in wbar.bar_graph.nodes:\n",
     "        ax.text(wbar.bar_graph.nodes[node]['poly'].centroid.x, wbar.bar_graph.nodes[node]['poly'].centroid.y, str(node))\n",
@@ -676,7 +694,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig = debug_bar_polygons_2(wbars[15], graph1, dt, saved_ts)"
+    "fig = debug_bar_polygons_2(wbars[2], graph1)"
    ]
   }
  ],
@@ -696,7 +714,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Update several functions to (1) allow non-uniform timestep in computation of migration rate; (2) add 'timestep' and 'curvature' as node attributes to line graph; and (3) use line graph 'timestep' and 'curvature' node attributes in creation of polygon graphs. This should make using meandergraph on real centerline/bankline data with irregular time intervals more straightforward. 